### PR TITLE
docs: Add comprehensive trademark protection roadmap and policy

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,9 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+Trademark Notice: "UnaMentis," the UnaMentis logo, and related marks are
+trademarks of Richard Amerman. This license does not grant permission to use
+these trademarks. See TRADEMARK.md for our trademark policy.

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,0 +1,165 @@
+# UnaMentis Trademark Policy
+
+## Overview
+
+This document describes the policy for use of the UnaMentis trademarks. While the UnaMentis source code is available under the MIT License, the UnaMentis name, logos, and other brand features are protected trademarks and are NOT covered by that license.
+
+## Trademark Ownership
+
+"UnaMentis," the UnaMentis logo (profile silhouette with wordmark), and the UnaMentis "UM" icon are trademarks of Richard Amerman. These marks identify the official UnaMentis project and distinguish it from unofficial derivatives.
+
+## Our Commitment to Open Source
+
+We believe in open source and want the community to be able to use, modify, and build upon UnaMentis. This trademark policy aims to balance:
+
+1. **Community freedom** to use, modify, and distribute the software
+2. **User clarity** about what is official UnaMentis vs. community derivatives
+3. **Brand integrity** to maintain trust in the UnaMentis name
+
+## Permitted Uses (No Permission Required)
+
+You **MAY** use UnaMentis trademarks without prior permission for:
+
+### Nominative Fair Use
+- Referring to UnaMentis in articles, blog posts, tutorials, or documentation
+- Stating factually that your project is "based on UnaMentis," "built with UnaMentis," or "compatible with UnaMentis"
+- Comparing your product to UnaMentis (provided claims are truthful)
+- Academic or research papers discussing UnaMentis
+
+### Community Activities
+- Writing tutorials or educational content about UnaMentis
+- Giving presentations or talks about UnaMentis
+- Discussing UnaMentis in podcasts, videos, or social media
+- Creating fan sites or community resources
+
+### Requirements for Permitted Uses
+When using our marks under nominative fair use, you must:
+- Use the mark only to refer to the actual UnaMentis project
+- Not suggest sponsorship, endorsement, or affiliation with UnaMentis
+- Not use our marks more prominently than your own brand
+- Include appropriate attribution when reasonable
+
+## Uses Requiring Permission
+
+You **MUST** obtain written permission before:
+
+### Product/Service Names
+- Using "UnaMentis" as part of your product or service name
+- Using "UnaMentis" in your company or organization name
+- Creating "UnaMentis [Something]" or "[Something] for UnaMentis" products
+
+### Commercial Use of Logos
+- Using UnaMentis logos in commercial products or services
+- Using UnaMentis logos in advertising or marketing materials
+- Printing UnaMentis logos on merchandise for sale
+
+### Domain Names
+- Registering domain names containing "UnaMentis"
+
+### Modified Software Distribution
+- Distributing modified versions under the UnaMentis name
+- Using UnaMentis branding for forks or derivatives
+
+## Prohibited Uses
+
+You may **NOT** under any circumstances:
+
+### Trademark Registration
+- Register "UnaMentis" or confusingly similar marks as trademarks
+- Register domain names containing "UnaMentis" in bad faith
+
+### Misleading Uses
+- Use our marks in ways that suggest official endorsement, sponsorship, or affiliation
+- Use our marks on products or services that violate our values or could harm our reputation
+- Create logos that are confusingly similar to UnaMentis logos
+
+### Logo Modifications
+- Modify, distort, or alter UnaMentis logos without permission
+- Combine UnaMentis logos with other logos or graphics
+- Use UnaMentis logos in a way that implies a partnership
+
+## Guidelines for Modified Versions
+
+If you distribute a modified version of UnaMentis under the MIT License:
+
+### You MUST:
+- Remove or replace all UnaMentis trademarks (name, logos, icons)
+- Choose a distinct name that does not include "UnaMentis"
+- Make clear that your version is not the official UnaMentis
+
+### You MAY:
+- State that your project is "based on UnaMentis" or "derived from UnaMentis"
+- Link to the official UnaMentis project
+- Include attribution in documentation
+
+### Suggested Naming Patterns
+```
+✅ "MyTutor (based on UnaMentis)"
+✅ "VoiceMentor - A UnaMentis Fork"
+✅ "EduVoice, powered by UnaMentis technology"
+
+❌ "UnaMentis Pro"
+❌ "UnaMentis Enterprise"
+❌ "UnaMentis Plus"
+❌ "OpenUnaMentis"
+❌ "UnaMentis Community Edition"
+```
+
+## Logo Usage Guidelines
+
+If you receive permission to use our logos:
+
+### Clear Space
+- Maintain minimum clear space equal to the height of the "U" around all sides
+- Never crowd the logo with other elements
+
+### Minimum Size
+- Expanded logo: minimum 120px width (digital) or 1 inch (print)
+- Compact logo: minimum 32px (digital) or 0.25 inch (print)
+
+### Approved Variations
+- Full color on white/light backgrounds
+- Full color on dark backgrounds (with approved contrast)
+- Monochrome black on white
+- Monochrome white on black/dark
+
+### Prohibited Treatments
+- Do not rotate or skew the logo
+- Do not change logo colors outside approved palettes
+- Do not add effects (shadows, glows, outlines)
+- Do not use the logo as a pattern or background
+- Do not animate the logo without permission
+
+## Reporting Violations
+
+If you become aware of any confusing or unauthorized use of UnaMentis trademarks, please report it to:
+
+**Email**: trademark@unamentis.com
+
+## Requesting Permission
+
+To request permission for uses not covered as "permitted," contact us at:
+
+**Email**: trademark@unamentis.com
+
+Please include:
+- Your name and organization
+- Description of intended use
+- Where and how the mark will be displayed
+- Mockups or examples if applicable
+
+We typically respond within 10 business days.
+
+## Changes to This Policy
+
+We may update this policy from time to time. Material changes will be announced through our usual communication channels. The current version will always be available in this repository.
+
+## Questions?
+
+If you're unsure whether your use is permitted, please ask! We're happy to clarify and generally want to enable legitimate community use.
+
+---
+
+*Last updated: January 2026*
+
+*This trademark policy is inspired by the trademark policies of Mozilla, Apache Software Foundation, Linux Foundation, and WordPress Foundation.*

--- a/docs/TRADEMARK_PROTECTION_ROADMAP.md
+++ b/docs/TRADEMARK_PROTECTION_ROADMAP.md
@@ -1,0 +1,677 @@
+# UnaMentis Trademark Protection Roadmap
+
+This document provides a comprehensive guide for protecting the UnaMentis trademark, logo, and related intellectual property through USPTO registration and international filings.
+
+## Table of Contents
+
+1. [Current State Assessment](#current-state-assessment)
+2. [Trademark Protection Strategy Overview](#trademark-protection-strategy-overview)
+3. [Phase 1: Pre-Filing Preparation](#phase-1-pre-filing-preparation)
+4. [Phase 2: USPTO Federal Registration](#phase-2-uspto-federal-registration)
+5. [Phase 3: International Protection](#phase-3-international-protection)
+6. [Phase 4: Open Source Trademark Policy](#phase-4-open-source-trademark-policy)
+7. [Phase 5: Company Formation & IP Assignment](#phase-5-company-formation--ip-assignment)
+8. [Ongoing Maintenance & Enforcement](#ongoing-maintenance--enforcement)
+9. [Timeline & Budget Estimates](#timeline--budget-estimates)
+10. [Appendices](#appendices)
+
+---
+
+## Current State Assessment
+
+### Existing Assets to Protect
+
+| Asset | Type | Files |
+|-------|------|-------|
+| **"UnaMentis" wordmark** | Standard character mark | N/A (text only) |
+| **Expanded logo** | Design mark (composite) | `images/UnaMentis_expanded_color.png` |
+| **Compact logo ("UM")** | Design mark | `images/UnaMentis_compact_color.png` |
+| **App icon** | Design mark | `UnaMentis/Assets.xcassets/AppIcon.appiconset/` |
+
+### Current IP Status
+
+- **Copyright**: MIT License, Copyright (c) 2025 Richard Amerman
+- **Trademark**: Unregistered (common law rights may exist through use)
+- **Domain**: (verify ownership of unamentis.com and variants)
+
+### Key Considerations
+
+1. **Open Source Context**: MIT License covers code, but NOT the trademark/branding
+2. **Commercial Intent**: Planning to form a company based on UnaMentis
+3. **Distinctiveness**: "UnaMentis" (Latin: "One Mind") is likely distinctive/suggestive, which is favorable for registration
+
+---
+
+## Trademark Protection Strategy Overview
+
+### Recommended Filing Strategy
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    TRADEMARK PORTFOLIO                          │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  1. STANDARD CHARACTER MARK: "UnaMentis"                       │
+│     └── Protects the name in ANY stylization                   │
+│                                                                 │
+│  2. DESIGN MARK: Expanded Logo (wordmark + profile)            │
+│     └── Protects the specific visual design                    │
+│                                                                 │
+│  3. DESIGN MARK: Compact Logo ("UM" + head silhouette)         │
+│     └── Protects the icon/app symbol                           │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Priority Order
+
+1. **Highest Priority**: Standard character mark "UnaMentis" (most versatile protection)
+2. **High Priority**: Expanded logo design mark
+3. **Medium Priority**: Compact "UM" logo design mark
+
+---
+
+## Phase 1: Pre-Filing Preparation
+
+### Step 1.1: Comprehensive Trademark Search (Week 1-2)
+
+Before filing, conduct thorough searches to identify potential conflicts.
+
+#### Free Preliminary Searches
+
+1. **USPTO TESS Database**
+   - URL: https://tess2.uspto.gov/
+   - Search for: "UnaMentis", "Una Mentis", "UNAMENTIS"
+   - Search phonetic equivalents and similar marks
+
+2. **State Trademark Databases**
+   - Each state maintains separate trademark registrations
+   - Focus on states where you'll do business (incorporation state, CA, NY, TX)
+
+3. **Domain Name Search**
+   - Check availability of: unamentis.com, unamentis.io, unamentis.app
+   - Check social media handles: @unamentis on Twitter/X, Instagram, GitHub
+
+4. **Common Law Search**
+   - Google search for "UnaMentis" in quotes
+   - Search app stores (Apple App Store, Google Play)
+   - Search business registries
+
+#### Professional Search (Recommended)
+
+| Service | Cost | Turnaround |
+|---------|------|------------|
+| USPTO Certified Search | $150-300 | 1-2 weeks |
+| Comprehensive Professional Search (Thomson Reuters, Corsearch) | $500-1,500 | 1-2 weeks |
+| Attorney-Conducted Search + Opinion | $1,000-3,000 | 2-4 weeks |
+
+**Recommendation**: At minimum, use USPTO's free TESS search. For commercial launch, invest in a professional comprehensive search ($500-1,500) to avoid costly conflicts later.
+
+### Step 1.2: Identify Goods/Services Classes (Week 1)
+
+USPTO uses the Nice Classification system. For UnaMentis, relevant classes include:
+
+#### Primary Classes (Must File)
+
+| Class | Description | Specific Goods/Services |
+|-------|-------------|------------------------|
+| **Class 9** | Computer software | "Downloadable mobile application software for educational purposes, namely, voice-based AI tutoring" |
+| **Class 42** | SaaS/Technology Services | "Providing temporary use of non-downloadable software for voice-based AI tutoring; Software as a service (SaaS) featuring software for educational purposes" |
+
+#### Secondary Classes (Consider)
+
+| Class | Description | Specific Goods/Services |
+|-------|-------------|------------------------|
+| **Class 41** | Education Services | "Educational services, namely, providing AI-powered tutoring services in the field of [subjects]" |
+| **Class 38** | Telecommunications | "Providing online voice communication services for educational purposes" |
+
+**Cost Impact**: Each additional class adds ~$250-350 to filing fees.
+
+### Step 1.3: Establish Date of First Use (Week 1)
+
+Document your earliest use of the UnaMentis mark in commerce:
+
+1. **First Use Anywhere**: Date you first used the mark (even internally)
+2. **First Use in Commerce**: Date you first used the mark in interstate/international commerce
+
+**Evidence to Preserve**:
+- Screenshots of app with dates
+- Git commit history showing first use of branding
+- Website archives (Wayback Machine)
+- Marketing materials, social media posts
+- Beta tester communications
+- App Store submission dates
+
+### Step 1.4: Prepare Specimens (Week 2)
+
+USPTO requires specimens showing the mark as actually used in commerce.
+
+#### For Software (Class 9)
+- Screenshot of app showing the mark
+- Screenshot of app store listing
+- Screenshot of download page
+
+#### For Services (Class 42)
+- Screenshot of website offering the service
+- Screenshot of app login/splash screen
+- Marketing materials showing the service
+
+**Requirements**:
+- Must show mark as customers encounter it
+- Must be in actual use (not mockups)
+- Digital files: JPG or PNG, max 5MB, 944x944 min, 3000x3000 max
+
+---
+
+## Phase 2: USPTO Federal Registration
+
+### Step 2.1: Choose Application Basis
+
+| Basis | When to Use | Requirements |
+|-------|-------------|--------------|
+| **Section 1(a) - Use in Commerce** | Already selling/offering the service | Specimens of actual use required |
+| **Section 1(b) - Intent to Use** | Planning to launch but not yet in commerce | Must file Statement of Use before registration |
+
+**Recommendation**: If the app is live in the App Store, use Section 1(a). If pre-launch, use Section 1(b).
+
+### Step 2.2: File USPTO Application (Week 3-4)
+
+#### Filing Options
+
+| Method | Cost per Class | Pros | Cons |
+|--------|---------------|------|------|
+| **TEAS Plus** | $250/class | Lowest cost | Must use USPTO's pre-approved descriptions |
+| **TEAS Standard** | $350/class | Custom descriptions | Higher cost |
+
+**Recommendation**: Start with TEAS Plus if your goods/services fit pre-approved descriptions.
+
+#### Filing Process
+
+1. **Create USPTO.gov Account**
+   - URL: https://www.uspto.gov/trademarks
+   - Create account at https://my.uspto.gov/
+
+2. **Prepare Application Information**
+   ```
+   Mark Type: Standard Character Mark (for wordmark)
+              Design Mark (for logos)
+
+   Owner: Richard Amerman (individual)
+          OR
+          [Company Name] LLC/Inc. (after formation)
+
+   Address: [Legal address for correspondence]
+
+   Basis: 1(a) Use in Commerce OR 1(b) Intent to Use
+
+   Goods/Services: [From Step 1.2]
+
+   First Use Date: [From Step 1.3]
+
+   Specimens: [From Step 1.4]
+   ```
+
+3. **File Applications**
+   - File standard character mark first
+   - File design marks separately (or together if budget allows)
+
+4. **Pay Fees**
+   - TEAS Plus: $250 per class per mark
+   - Example: 2 classes × 3 marks = $1,500 minimum
+
+### Step 2.3: USPTO Examination Process (Months 3-12)
+
+```
+Timeline:
+┌──────────────────────────────────────────────────────────────────┐
+│ Month 0   │ Application Filed                                    │
+│ Month 3-6 │ Assigned to Examining Attorney                       │
+│ Month 4-8 │ Office Action (if issues found) - 6 months to respond│
+│ Month 6-10│ Publication in Official Gazette (30-day opposition)  │
+│ Month 8-12│ Registration Certificate Issued                      │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+#### Common Office Actions & Responses
+
+| Issue | Response Strategy |
+|-------|-------------------|
+| **Likelihood of Confusion** | Argue differences in marks, goods/services, trade channels |
+| **Merely Descriptive** | Argue suggestiveness, submit evidence of acquired distinctiveness |
+| **Specimen Issues** | Submit corrected specimens showing actual use |
+| **Description Too Broad** | Narrow goods/services description |
+
+**Pro Tip**: Consider hiring a trademark attorney for Office Action responses ($500-2,000).
+
+### Step 2.4: Post-Registration Requirements
+
+| Deadline | Requirement | Fee |
+|----------|-------------|-----|
+| **Years 5-6** | Section 8 Declaration of Use | $225/class |
+| **Years 5-6** | Section 15 Declaration of Incontestability (optional but recommended) | $200/class |
+| **Years 9-10** | Section 8 Declaration + Section 9 Renewal | $525/class |
+| **Every 10 years** | Section 8 + Section 9 | $525/class |
+
+---
+
+## Phase 3: International Protection
+
+### Option A: Madrid Protocol (Recommended)
+
+The Madrid Protocol allows you to extend your US registration to 130+ countries through a single application.
+
+#### Process
+
+1. **Wait for USPTO Application/Registration**
+   - Can file based on pending application or registration
+
+2. **File Through USPTO**
+   - USPTO acts as "Office of Origin"
+   - Single application, single fee structure
+
+3. **Designate Countries**
+   - Select countries where you want protection
+   - Each country examines independently
+
+#### Cost Structure
+
+| Component | Cost |
+|-----------|------|
+| Basic Fee | CHF 653 (~$730 USD) |
+| Supplementary Fee (per class) | CHF 100 (~$112 USD) |
+| Individual Country Fees | Varies by country |
+
+**Example Budget for Key Markets**:
+| Country | Individual Fee (CHF) |
+|---------|---------------------|
+| European Union (all 27 countries) | 914 |
+| United Kingdom | 243 |
+| China | 249 |
+| Japan | 0 (uses supplementary) |
+| Australia | 390 |
+| Canada | 347 |
+
+**Total for EU + UK + China + Japan + Australia + Canada**: ~CHF 2,896 (~$3,240 USD) + basic fees
+
+### Option B: Direct National Filings
+
+For countries not in Madrid Protocol or for strategic reasons:
+
+| Country | Office | Approximate Cost |
+|---------|--------|------------------|
+| Canada | CIPO | CAD 458+ |
+| India | IP India | INR 9,000+ |
+| Brazil | INPI | BRL 415+ |
+
+### Priority Countries for UnaMentis
+
+Based on EdTech market size and English-speaking markets:
+
+| Priority | Countries | Rationale |
+|----------|-----------|-----------|
+| 1 | United States | Primary market |
+| 2 | European Union | Large EdTech market, single filing |
+| 3 | United Kingdom | Post-Brexit, separate filing needed |
+| 4 | Canada | English-speaking, USMCA alignment |
+| 5 | Australia | English-speaking EdTech market |
+| 6 | India | Large English-speaking population |
+
+---
+
+## Phase 4: Open Source Trademark Policy
+
+### Why This Matters
+
+Your MIT License grants broad rights to the code, but does NOT grant rights to your trademarks. You need a clear policy to:
+
+1. Allow legitimate community use
+2. Prevent confusion about official vs. unofficial versions
+3. Protect brand integrity while fostering open source community
+
+### Create a TRADEMARK.md File
+
+Create a trademark policy document in your repository:
+
+```markdown
+# UnaMentis Trademark Policy
+
+## Trademark Ownership
+
+"UnaMentis," the UnaMentis logo, and the UnaMentis "UM" icon are trademarks
+of [Company Name / Richard Amerman]. While our software is available under
+the MIT License, our trademarks are not.
+
+## Permitted Uses (No Permission Needed)
+
+You MAY use our trademarks to:
+- Refer to UnaMentis in articles, tutorials, or documentation
+- State that your project is "based on UnaMentis" or "compatible with UnaMentis"
+- Use in academic/research contexts with proper attribution
+
+## Restricted Uses (Permission Required)
+
+You MUST obtain written permission to:
+- Use "UnaMentis" in your product or service name
+- Use our logos in any commercial context
+- Create merchandise with our marks
+- Imply official endorsement or affiliation
+
+## Prohibited Uses
+
+You may NOT:
+- Register "UnaMentis" or confusingly similar marks as trademarks
+- Use our marks in domain names for commercial purposes
+- Modify our logos without permission
+- Use our marks in ways that suggest official endorsement
+
+## Requesting Permission
+
+Contact: [trademark@unamentis.com]
+
+## Examples
+
+✅ ALLOWED: "This tutorial uses UnaMentis"
+✅ ALLOWED: "MyApp integrates with UnaMentis"
+❌ NOT ALLOWED: "UnaMentis Pro" (implies official product)
+❌ NOT ALLOWED: "UnaMentis Certified Tutoring"
+```
+
+### Update LICENSE File
+
+Consider adding a trademark notice to your LICENSE file:
+
+```
+MIT License
+
+Copyright (c) 2025 Richard Amerman
+
+[... existing MIT text ...]
+
+---
+
+Trademark Notice: "UnaMentis," the UnaMentis logo, and related marks are
+trademarks of [Company Name]. This license does not grant permission to
+use these trademarks. See TRADEMARK.md for our trademark policy.
+```
+
+### Models from Other Open Source Projects
+
+Study these established policies:
+- **Mozilla**: https://www.mozilla.org/en-US/foundation/trademarks/policy/
+- **Linux Foundation**: https://www.linuxfoundation.org/trademark-usage
+- **Apache**: https://www.apache.org/foundation/marks/
+- **WordPress**: https://wordpressfoundation.org/trademark-policy/
+
+---
+
+## Phase 5: Company Formation & IP Assignment
+
+### Timing Considerations
+
+```
+Option A: File trademarks personally, assign to company later
+├── Pros: Can start immediately, no company formation delay
+├── Cons: Assignment fees (~$100/mark), potential complications
+└── Best if: Urgency to file, company formation timeline uncertain
+
+Option B: Form company first, file trademarks in company name
+├── Pros: Clean ownership, no assignment needed
+├── Cons: Delays trademark filing, company formation costs
+└── Best if: Company formation imminent (< 2 months)
+```
+
+**Recommendation**: If company formation is within 2-3 months, wait and file in company name. Otherwise, file personally and assign later.
+
+### IP Assignment Process
+
+If you file personally first, you'll need to assign to the company:
+
+1. **Execute Assignment Agreement**
+   - Written agreement transferring trademark rights
+   - Include goodwill associated with the mark
+   - Both parties sign
+
+2. **Record with USPTO**
+   - File assignment via ETAS (Electronic Trademark Assignment System)
+   - URL: https://etas.uspto.gov/
+   - Fee: $100 per mark
+
+3. **Update All Records**
+   - Update owner information with USPTO
+   - Update any international registrations
+
+### Company Structure Considerations
+
+| Structure | Trademark Implications |
+|-----------|----------------------|
+| **LLC** | Simple assignment, pass-through taxation |
+| **C-Corp** | Preferred for VC funding, clean IP ownership |
+| **Delaware** | Common for tech companies, established case law |
+
+### Founder IP Assignment
+
+When forming the company, include trademark rights in the standard IP assignment:
+
+```
+Sample Assignment Language:
+
+Assignor hereby assigns to Company all right, title, and interest in:
+(a) The trademarks listed in Exhibit A, including all registrations and
+    applications therefor, and all goodwill associated therewith;
+(b) All trade names, service marks, logos, and brand names associated
+    with the Business;
+(c) [Standard patent/copyright assignment language]
+```
+
+---
+
+## Ongoing Maintenance & Enforcement
+
+### Trademark Watching Service
+
+Subscribe to a watching service to monitor for conflicting applications:
+
+| Service | Cost | Coverage |
+|---------|------|----------|
+| USPTO Alerts (DIY) | Free | US only |
+| TrademarkNow | $200-500/year | Global |
+| Corsearch | $500-2,000/year | Comprehensive |
+
+### Enforcement Actions
+
+| Situation | Response | Estimated Cost |
+|-----------|----------|----------------|
+| Similar app in App Store | Takedown notice to Apple | Free-$500 |
+| Infringing domain name | UDRP proceeding | $1,500-5,000 |
+| Copycat product | Cease & desist letter | $500-2,000 |
+| Serious infringement | Federal litigation | $50,000+ |
+
+### Proper Trademark Usage
+
+Always use your marks properly:
+
+```
+✅ Correct Usage:
+- "UnaMentis® voice tutoring app" (after registration)
+- "UnaMentis™ voice tutoring app" (before registration)
+- "Download the UnaMentis app"
+
+❌ Incorrect Usage:
+- "Download Unamentis" (wrong capitalization)
+- "I love unamentising" (using as verb)
+- "My UnaMentis" (using as generic noun)
+```
+
+### Style Guide Requirements
+
+Create internal brand guidelines specifying:
+- Correct capitalization: "UnaMentis" (not "Unamentis" or "UNAMENTIS")
+- Logo clear space and minimum sizes
+- Approved color variations
+- Trademark symbols (™ before registration, ® after)
+
+---
+
+## Timeline & Budget Estimates
+
+### Recommended Timeline
+
+```
+Week 1-2:   Phase 1 - Pre-filing preparation
+            ├── Conduct preliminary searches
+            ├── Identify classes
+            └── Gather specimens
+
+Week 3-4:   Phase 2 - USPTO Filing
+            ├── File standard character mark
+            └── File design marks
+
+Week 4-6:   Phase 4 - Open Source Policy
+            ├── Create TRADEMARK.md
+            └── Update LICENSE
+
+Month 3-12: USPTO Examination
+            └── Respond to any Office Actions
+
+Month 6-12: Phase 3 - International Filing
+            └── File Madrid Protocol application
+
+Month 6+:   Phase 5 - Company Formation
+            ├── Form LLC/Corp
+            └── Execute IP assignment
+```
+
+### Budget Summary
+
+#### Minimum Viable Protection (DIY)
+
+| Item | Cost |
+|------|------|
+| USPTO search (free TESS) | $0 |
+| USPTO filing - 1 mark, 2 classes (TEAS Plus) | $500 |
+| **Total** | **$500** |
+
+#### Recommended Protection
+
+| Item | Cost |
+|------|------|
+| Professional trademark search | $800 |
+| USPTO filing - 3 marks, 2 classes each | $1,500 |
+| Attorney review of application | $500 |
+| **Total** | **$2,800** |
+
+#### Comprehensive Protection (with International)
+
+| Item | Cost |
+|------|------|
+| Professional trademark search (US + international) | $2,000 |
+| USPTO filing - 3 marks, 2 classes each | $1,500 |
+| Attorney preparation and filing | $2,000 |
+| Madrid Protocol - 5 countries | $4,000 |
+| Trademark watching service (1 year) | $500 |
+| **Total** | **$10,000** |
+
+---
+
+## Appendices
+
+### Appendix A: Key USPTO Links
+
+| Resource | URL |
+|----------|-----|
+| USPTO Main | https://www.uspto.gov/trademarks |
+| TESS Search | https://tess2.uspto.gov/ |
+| TEAS Filing | https://teas.uspto.gov/ |
+| TSDR Status | https://tsdr.uspto.gov/ |
+| ID Manual | https://idm-tmng.uspto.gov/id-master-list-public.html |
+| Fee Schedule | https://www.uspto.gov/trademark/fees-payment-information |
+
+### Appendix B: International Resources
+
+| Resource | URL |
+|----------|-----|
+| WIPO Madrid System | https://www.wipo.int/madrid/en/ |
+| Madrid Fee Calculator | https://www.wipo.int/madrid/en/fees/calculator.jsp |
+| EUIPO (EU) | https://euipo.europa.eu/ |
+| UK IPO | https://www.gov.uk/government/organisations/intellectual-property-office |
+
+### Appendix C: Sample Cease & Desist Template
+
+```
+[Your Letterhead]
+[Date]
+
+[Infringer Name]
+[Address]
+
+Re: Unauthorized Use of UnaMentis Trademark
+
+Dear [Name]:
+
+We are the owners of the federally registered trademark UNAMENTIS
+(Registration No. [X,XXX,XXX]) for [goods/services].
+
+It has come to our attention that you are using [description of
+infringing use] in connection with [their goods/services].
+
+Your use of [infringing mark] is likely to cause confusion among
+consumers as to the source of your goods/services and constitutes
+trademark infringement under 15 U.S.C. § 1114.
+
+We demand that you:
+1. Immediately cease all use of the UNAMENTIS mark
+2. Remove all infringing materials from [website/products]
+3. Confirm compliance within [14] days
+
+Failure to comply may result in legal action seeking injunctive
+relief and damages.
+
+Sincerely,
+[Your Name]
+```
+
+### Appendix D: Checklist
+
+#### Pre-Filing Checklist
+- [ ] Completed USPTO TESS search
+- [ ] Completed state trademark searches
+- [ ] Completed common law search (Google, app stores)
+- [ ] Identified Nice Classification classes
+- [ ] Documented first use date with evidence
+- [ ] Prepared specimens for each class
+- [ ] Decided on filing basis (1a or 1b)
+- [ ] Determined owner (personal or company)
+
+#### Filing Checklist
+- [ ] Created USPTO.gov account
+- [ ] Prepared goods/services descriptions
+- [ ] Uploaded specimens
+- [ ] Paid filing fees
+- [ ] Saved serial number(s)
+- [ ] Set calendar reminders for deadlines
+
+#### Post-Filing Checklist
+- [ ] Monitor TSDR for status updates
+- [ ] Respond to Office Actions within 6 months
+- [ ] Monitor publication in Official Gazette
+- [ ] File Statement of Use (if 1b application)
+- [ ] Set reminders for maintenance deadlines
+
+#### Brand Protection Checklist
+- [ ] Created TRADEMARK.md policy
+- [ ] Updated LICENSE file
+- [ ] Created brand style guide
+- [ ] Set up trademark watching service
+- [ ] Documented proper trademark usage
+
+---
+
+## Document History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2026-01-03 | Claude | Initial roadmap |
+
+---
+
+*Disclaimer: This document provides general information about trademark protection. It is not legal advice. Consult with a qualified trademark attorney for advice specific to your situation.*


### PR DESCRIPTION
- Add TRADEMARK_PROTECTION_ROADMAP.md with detailed guidance for USPTO
  filing, international protection via Madrid Protocol, and timeline/budget
  estimates for trademark registration
- Add TRADEMARK.md policy defining permitted and prohibited uses of
  UnaMentis marks for open source community
- Update LICENSE with trademark notice clarifying trademarks are not
  covered by MIT license

Covers protection strategy for the UnaMentis wordmark, expanded logo,
and compact "UM" icon across US and international jurisdictions.