### PR TITLE
Point architecture demo deploys at UMSE_CLOUDFLARE_API_TOKEN

### DIFF
--- a/.github/workflows/architecture-full.yml
+++ b/.github/workflows/architecture-full.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Create Cloudflare Pages project (if needed)
         env:
-          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_API_TOKEN: ${{ secrets.UMSE_CLOUDFLARE_API_TOKEN }}
           CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           # Check if project exists
@@ -86,14 +86,14 @@ jobs:
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          apiToken: ${{ secrets.UMSE_CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy .solution-explorer/viewer/dist --project-name=solution-explorer-unamentis --branch=main --commit-dirty=true
 
       - name: Remove domain from old project (if exists)
         continue-on-error: true
         env:
-          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_API_TOKEN: ${{ secrets.UMSE_CLOUDFLARE_API_TOKEN }}
           CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           curl -s -X DELETE \
@@ -104,7 +104,7 @@ jobs:
       - name: Add custom domain to new project
         continue-on-error: true
         env:
-          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_API_TOKEN: ${{ secrets.UMSE_CLOUDFLARE_API_TOKEN }}
           CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           # Check if domain already exists on this project
@@ -144,7 +144,7 @@ jobs:
       - name: Create DNS record
         continue-on-error: true
         env:
-          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_API_TOKEN: ${{ secrets.UMSE_CLOUDFLARE_API_TOKEN }}
           CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           ZONE_ID="8187e1e6b3b194f2ecc55ebc754389b8"

--- a/.github/workflows/architecture.yml
+++ b/.github/workflows/architecture.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           config: solution-explorer.json
           deploy-to: cloudflare
-          cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          cloudflare-api-token: ${{ secrets.UMSE_CLOUDFLARE_API_TOKEN }}
           cloudflare-account-id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           cloudflare-project-name: um-solution-explorer
 


### PR DESCRIPTION
Fixes the failing "Advanced Architecture Visualization" deploy. `architecture-full.yml` (full demo at solution-explorer.unamentis.org) failed at "Create Cloudflare Pages project" with `Error: Authentication error` because it used the older `CLOUDFLARE_API_TOKEN`, which no longer has Pages Edit. This repoints both the full and static architecture workflows to `UMSE_CLOUDFLARE_API_TOKEN` (account-level Pages Edit, the token already used by the iOS architecture deploy). Account id, project names, and all other references unchanged. The DNS/domain steps are continue-on-error and do not gate the deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment automation to use the current Cloudflare authentication credential.
  * Improved reliability for site deployment, domain configuration, and DNS updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->